### PR TITLE
FIX - Remove staging site navbar

### DIFF
--- a/_includes/navbar.html
+++ b/_includes/navbar.html
@@ -1,3 +1,4 @@
+{% assign navurl = page.url | remove: 'index.html' %}
   <nav class="site-navigation" id="top">
     <div class="container">
       <div class="navbar-header">
@@ -9,22 +10,23 @@
           <span class="icon-bar"></span>
         </button>
         <!-- Your site title as branding in the menu -->
-        <a class="navbar-brand active" href="http://staging.verapdf.org/" title="veraPDF" rel="home"><div id="menu-logo">&nbsp;</div></a>
+        <a class="navbar-brand active" href="http://verapdf.org/" title="veraPDF" rel="home"><div id="menu-logo">&nbsp;</div></a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
         <ul class="nav navbar-nav navbar-right">
           <li><a href="http://github.com/veraPDF/"><i class="fa fa-github"></i> GitHub</a></li>
-          <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
         </ul>
         <!-- The WordPress Menu goes here -->
         <ul id="main-menu" class="nav navbar-nav navbar-right">
-          <li class="active"><a title="Docs" href="/">Docs</a></li>
-          <li><a title="Resources" href="http://staging.verapdf.org/resources/">Resources</a></li>
-          <li><a title="News" href="http://staging.verapdf.org/news/">News</a></li>
-          <li><a title="Community" href="http://staging.verapdf.org/community/">Community</a></li>
-          <li><a title="Open Source" href="http://staging.verapdf.org/open-source/">Open Source</a></li>
-          <li><a title="PDF/A Validation" href="http://staging.verapdf.org/pdfa-validation/">PDF/A Validation</a></li>
-          <li><a title="About" href="http://staging.verapdf.org/about/">About</a></li>
+          {% for item in include.nav %}
+              {% if item.href == navurl %}
+              <li class="active">
+              {% else %}
+              <li>
+              {% endif %}
+              <a href="{{ site.url }}{{ item.href }}">{{ item.title }}</a>
+            </li>
+          {% endfor %}
         </ul>
       </div><!-- #navbar -->
     </div><!-- .container -->

--- a/_layouts/page.html
+++ b/_layouts/page.html
@@ -1,7 +1,6 @@
 {% include header.html %}
 <body role="document">
-{% include navbar.html %}
-{% include docnav.html nav=site.data.docnav %}
+{% include navbar.html nav=site.data.docnav %}
 <section class="main-content">
     <div class="container">
       <div class="row">


### PR DESCRIPTION
- removed top navbar with staging links;
- removed staging site download link;
- replaced staging nav with docs navigation; and
- changed logo URL to main veraPDF site.
