### PR TITLE
EXAMP - Running veraPDF without installation

### DIFF
--- a/cli/config/index.md
+++ b/cli/config/index.md
@@ -6,6 +6,9 @@ title: veraPDF CLI Configuration
 {{ page.title }}
 ================
 
+Introduction
+------------
+
 Below the veraPDF installation directory there is a sub-directory called
 `config`. This contains the XML configuration files for the veraPDF software
 components. To see the contents of this directory from a terminal session
@@ -33,13 +36,45 @@ installation. The software generates default configuration files on start-up if
 none exist. Try running <kbd>verapdf --version</kbd> which should generate the
 missing files.
 
+### Running veraPDF without installation gives no configuration files
+All of the aboive assumes that you've installed veraPDF with the downloaded
+installer. If you're running a version of the application you've built
+yourself and not installed you won't have an application home directory. The
+following only applies if you're running a jar directly from the command line,
+that is something like:
+
+    java -jar target/gui-1.1.0-SNAPSHOT.jar
+
+from the [`veraPDF-apps/gui` module](https://github.com/veraPDF/veraPDF-apps/tree/integration/gui).
+The problem is that the installer adds a couple of invocation scripts that set
+up the application home directory. The solution is to choose a config directory
+and pass it to the application when you call it. Here's an example:
+
+1, Select a folder you want to use as home and create it, a good suggestion is `~/.verapdf` beneath your home directory, in my case `/home/cfw/.verapdf`.
+2. Execute the following command: `java -Dapp.home="/home/cfw/.verapdf" -jar gui-1.1.0-SNAPSHOT.jar --version`
+3. `ls ~/.verapdf/config`
+
+and you should see
+
+    -rw-rw-r-- 1 cfw cfw 375 Jan 28 20:36 app.xml
+    -rw-rw-r-- 1 cfw cfw 186 Jan 28 20:36 features.xml
+    -rw-rw-r-- 1 cfw cfw 109 Jan 28 20:36 fixer.xml
+    -rw-rw-r-- 1 cfw cfw   0 Jan 28 20:36 plugins.xml
+    -rw-rw-r-- 1 cfw cfw 131 Jan 28 20:36 validator.xml
+
+Now proceed to use the config files in this directory, which will work as long as you use `java -Dapp.home="/home/cfw/.verapdf" -jar gui-1.1.0-SNAPSHOT.jar` as oppose to `java -jar gui-1.0.0.jar` when you start the app. This form of invocation supports all command line options, e.g.
+
+- `java -Dapp.home="/home/cfw/.verapdf" -jar gui-1.1.0-SNAPSHOT.jar -f 1b somefile.pdf`
+- `java -Dapp.home="/home/cfw/.verapdf" -jar gui-1.1.0-SNAPSHOT.jar --extract somefile.pdf`
+- `java -Dapp.home="/home/cfw/.verapdf" -jar gui-1.1.0-SNAPSHOT.jar --policyfile my-policy.sch somefile.pdf`
+
+### veraPDF config files
 There are four config files available:
 
 - `app.xml` configures the veraPDF CLI and GUI applications;
 - `validator.xml` sets defaults for PDF/A validation;
 - `fixer.xml` provides configuration of the metadata fixer; and
 - `features.xml` configures feature extraction.
-
 
 The sections below give a brief overview of these files and their options.
 


### PR DESCRIPTION
- added instructions for configuring app.home with no installation script.