### PR TITLE
Fix Creative Commons logo in footer

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -29,7 +29,7 @@
   <hr/>
   <div class="row">
     <div class="site-info small">
-            <a rel="license" href="http://creativecommons.org/licenses/by/4.0/"><i class="fa fa-cc fa-2x"></i></a>
+            <a rel="license" href="http://creativecommons.org/licenses/by/4.0/"><i class="fa fa-creative-commons fa-2x"></i></a>
       <p>Except where otherwise noted content created by the <a xmlns:cc="http://creativecommons.org/ns#" href="https://www.verapdf.org" property="cc:attributionName" rel="cc:attributionURL"> veraPDF Consortium</a> is licensed under a <a rel="license" href="http://creativecommons.org/licenses/by/4.0/">Creative Commons Attribution 4.0 International License</a>.</p>
       <p>Copyright &copy; 2015 - <script type="text/javascript">document.write( new Date().getFullYear() );</script> veraPDF consortium</p>
     </div><!-- close .site-info -->


### PR DESCRIPTION
The current `fa-cc` icon is actually the symbol for closed captioning. As both are "CC", and I found no explicit intention for this, I believe this is a typo. Feel free to reject this pull request if it was an intentional design choice.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the Creative Commons license badge icon in the footer for improved visual accuracy.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->